### PR TITLE
Update README.md: Explain how to deal with updates in sub-projects dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ This is an example of a monorepo managed by [PDM](https://pdm.fming.dev).
 If you change the dependencies in one of the subprojects, the `pdm install` command will not detect that the lock file needs to be re-generated.
 
 You will thus have to run `pdm lock` manually, before running `pdm install`. 
+
+Alternatively, you may for example run `pdm update pkg-first`, if you modified the depedencies of the `pkg-first` sub-project.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is an example of a monorepo managed by [PDM](https://pdm.fming.dev).
 - `packages/pkg-second`
 
 
-## Note about `pdm instal
+## Note about `pdm install`
 
 
 If you change the dependencies in one of the subprojects, the `pdm install` command will not detect that the lock file needs to be re-generated.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ This is an example of a monorepo managed by [PDM](https://pdm.fming.dev).
 - `packages/pkg-core`
 - `packages/pkg-first`
 - `packages/pkg-second`
+
+
+## Note about `pdm instal
+
+
+If you change the dependencies in one of the subprojects, the `pdm install` command will not detect that the lock file needs to be re-generated.
+
+You will thus have to run `pdm lock` manually, before running `pdm install`. 


### PR DESCRIPTION
Hello, thanks a lot for this example repo. 

This issue bugged me for some time (until I realized that `pdm lock` indeed re-generated the lock file correctly).

I first thought there was a deeper bug, that prevented taking into account modifications in the dependencies of the sub-projects.




